### PR TITLE
Encode query param values

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ Driver.prototype.search = function(params) {
   * }]
   */
   var qs = params.map(function(param) {
-    return [param.key, param.value].join('=');
+    return [param.key, encodeURIComponent(param.value)].join('=');
   }).join('&');
   return request.get(this.AUTH_URL + '/entities?'+ qs);
 };


### PR DESCRIPTION
Parameters with reserved values (eg. "+") are being stripped over the wire.  This branch encodes them correctly for safe travel.